### PR TITLE
Return updated object instead of new query

### DIFF
--- a/graphql/mutations/user/update.js
+++ b/graphql/mutations/user/update.js
@@ -19,8 +19,11 @@ export default {
 		}
 	},
 	resolve(root, params) {
-		return UserModel.findByIdAndUpdate(params.id, { $set: { ...params.data } })
-		.then(data => UserModel.findById(data.id).exec())
+		return UserModel.findByIdAndUpdate(
+			params.id,
+			{ $set: { ...params.data } },
+			{ new: true }
+		)
 		.catch(err => new Error('Couldn\'t Update User data, ', err));
 	}
 }


### PR DESCRIPTION
Make Mongoose return the updated object instead of the old one and executing another query for the new data. This is done by passing the "new: true" option to findByIdAndUpdate which defaults to false.